### PR TITLE
MTL-2025 Conflict with `cray-node-identity`

### DIFF
--- a/csm-node-identity.spec
+++ b/csm-node-identity.spec
@@ -30,6 +30,9 @@ License: MIT
 BuildArchitectures: noarch
 BuildRequires: systemd
 Requires: iproute2
+Obsoletes: cray-node-identity
+Conflicts: cray-node-identity
+Provides: cray-node-identity
 
 %{!?_unitdir:
 %define _unitdir /usr/lib/systemd/system


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-2025

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This change ensures `csm-node-identity` and `cray-node-identity` can't be installed together, despite having `%files` conflicts this explicitly states they conflict. This also states that this package obsoletes `cray-node-identity`, and that this provides the same package.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
